### PR TITLE
Making hypothesis examples smaller to avoid timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+env:
+  - HYPOTHESIS_PROFILE=ci
 python:
   - "2.7"
   - "3.4"

--- a/pyaptly/graph_test.py
+++ b/pyaptly/graph_test.py
@@ -15,7 +15,7 @@ if sys.version_info < (2, 7):  # pragma: no cover
     example = mock.MagicMock()  # noqa
     st = mock.MagicMock()  # noqa
 
-RES_COUNT = 35
+RES_COUNT = 20
 
 range_intagers_st = st.integers(min_value=0, max_value=RES_COUNT)
 
@@ -25,10 +25,10 @@ def provide_require_st(draw, filter_=True):
     commands = draw(range_intagers_st)
     provides = draw(
         st.lists(
-            st.lists(range_intagers_st),
+            st.lists(range_intagers_st, max_size=10),
             min_size = commands,
             max_size = commands
-        )
+        ),
     )
     is_func = draw(
         st.lists(
@@ -53,7 +53,7 @@ def provide_require_st(draw, filter_=True):
                 provides_filter = provides_set
             if provides_filter:
                 sample = st.sampled_from(provides_filter)
-                requires.append(draw(st.lists(sample)))
+                requires.append(draw(st.lists(sample, max_size=10)))
             else:
                 requires.append([])
     else:

--- a/pyaptly/test_test.py
+++ b/pyaptly/test_test.py
@@ -26,13 +26,14 @@ yml_st = st.recursive(
     st.floats(-1, 1) | st.booleans() |
     st.text() | st.none() | st.binary(),
     lambda children: st.lists(
-        children, average_size=5, max_size=15
+        children, average_size=5, max_size=10
     ) | st.dictionaries(
         st.text(),
         children,
         average_size=5,
-        max_size=15
-    )
+        max_size=10
+    ),
+    max_leaves=30
 )
 
 


### PR DESCRIPTION
on travis.

* The dependency-graphs now have only 20 commands
* A command provides/requires max 10 commands
* The yaml merge test now has a max length of 10 per leave
* The yaml merge test now has a max of 30 leaves
* Allowing deeper testing on Travis (max examples=10000)