### PR TITLE
Explicitly remove gnupg socket file before copy.

### DIFF
--- a/pyaptly/test.py
+++ b/pyaptly/test.py
@@ -155,6 +155,10 @@ def clean_and_config(test_input, freeze="2012-10-10 10:10:10"):
                 shutil.rmtree("%s/.gnupg" % new_home.decode("UTF-8"))
             except OSError:  # pragma: no cover
                 pass
+            try:
+                os.unlink('%s/.gnupg/S.gpg-agent' % old_home.decode("UTF-8"))
+            except OSError:
+                pass
             shutil.copytree(
                 "%s/.gnupg/" % old_home.decode("UTF-8"),
                 "%s/.gnupg" % new_home.decode("UTF-8")


### PR DESCRIPTION
In some configurations / distributions, GnuPG insists on having a socket
file in ~/.gnupg, which prevents the copying that directory (shutil.copytree
is not smart enough to detect sockets).

So, we remove the socket before the copy, if it exists.