### PR TITLE
setup.py: Set url to GitHub repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     description = "Aptly mirror/snapshot managment automation.",
     long_description = README_TEXT,
     keywords = "aptly mirror snapshot automation",
-    url = "https://adfinis-sygroup.ch",
+    url = "https://github.com/adfinis-sygroup/pyaptly",
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",


### PR DESCRIPTION
I'd say the GitHub repo is more useful when a potential user is looking at the PyPI page and you already have your company URL in the author_email field.