### PR TITLE
Do not expect dict-snapshots to contain timestamps

### DIFF
--- a/pyaptly/__init__.py
+++ b/pyaptly/__init__.py
@@ -1354,6 +1354,9 @@ def snapshot_spec_to_name(cfg, snapshot):
     delta = datetime.timedelta(seconds=1)
     if hasattr(snapshot, 'items'):
         name      = snapshot['name']
+        if 'timestamp' not in snapshot:
+            return name
+
         ts        = snapshot['timestamp']
         back_ref  = back_reference_map.get(ts)
         if back_ref is None:

--- a/pyaptly/aptly_test.py
+++ b/pyaptly/aptly_test.py
@@ -6,7 +6,8 @@ import os
 import freezegun
 import testfixtures
 
-from pyaptly import Command, SystemStateReader, call_output, main
+from pyaptly import (Command, SystemStateReader, call_output, main,
+                     snapshot_spec_to_name)
 
 from . import test
 
@@ -739,12 +740,12 @@ def test_publish_updating_basic():
                 'fakerepo02-20121006T0000Z',
                 'fakerepo01-20121010T0000Z',
             ])
-            assert expect ==  state.snapshots
+            assert expect == state.snapshots
             expect = {
                 'fakerepo02 main': set(['fakerepo02-20121006T0000Z']),
                 'fakerepo01 main': set(['fakerepo01-20121011T0000Z'])
             }
-            assert expect ==  state.publish_map
+            assert expect == state.publish_map
 
 
 def do_repo_create(config):
@@ -815,3 +816,21 @@ def test_repo_create_basic():
             b"repo.yml",
     )) as (tyml, config):
         do_repo_create(config)
+
+
+def test_snapshot_spec_as_dict():
+    "Test various snapshot formats for snapshot_spec_to_name()"
+
+    snap_string = 'snapshot-foo'
+    snap_dict = {
+        'name': 'foo'
+    }
+
+    cfg = {
+        'snapshot': {
+            'foo': {},
+        }
+    }
+
+    assert snapshot_spec_to_name(cfg, snap_string) == snap_string
+    assert snapshot_spec_to_name(cfg, snap_dict) == 'foo'


### PR DESCRIPTION
Snapshots can be referred to by name (string) or via dict,
which may contain a timestamp placeholder. This however is
not true in any case. Sometimes, dict-snapshots are just another
way of writing the name.

Therefore we cannot assume the "dict" form to contain a timestamp.