### PR TITLE
Added additional option to skip contents file generation in publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /pyaptly.egg-info
 *.swp
 *.pyc
+.python-version
 __pycache__
 /.cache
 /.hypothesis

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -222,3 +222,6 @@ Additional fields are:
       default-cache-ttl 31536000  # A Year
 
       max-cache-ttl 31536000
+
+   skip-contents
+    If true pyaptly will tell aptly not generate contents index files

--- a/pyaptly/publish.yml
+++ b/pyaptly/publish.yml
@@ -7,6 +7,7 @@ publish:
           timestamp: "current"
           archive-on-update: "archived-fakerepo01-%T"
       gpg-key: "650FE755"
+      skip-contents: true
       automatic-update: true
   fakerepo02:
     -


### PR DESCRIPTION
Since aptly version 0.9.6 aptly per default also creates content files.

With large repositories this can take quiet some time but also cause memory allocation issues
see https://github.com/smira/aptly/issues/415

Therefore I added an additional option to pyaptly to be able to skip contents file for specific repos.