### PR TITLE
Add python26 tests

### DIFF
--- a/.requirements.txt
+++ b/.requirements.txt
@@ -1,3 +1,3 @@
 mock
 freezegun
-hypothesis-datetime
+pytz

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 env:
   - HYPOTHESIS_PROFILE=ci
 python:
+  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,17 @@ GIT_HUB := "https://github.com/adfinis-sygroup/pyaptly"
 
 include pyproject/Makefile
 
+PYTHON26 := $(shell echo $(PYTHON_VERSION) | grep -Eq 2.6 && echo True 2> /dev/null)
+
+# not all comprehensions are supported in 2.6 therefore
+# need to disable linter for such
+DEVNULL := $(shell touch .deps/flake8_comprehensions)
+
+ifeq ($(PYTHON26),True)
+	# disable installation of hypothesis on python version <2.7
+	DEVNULL := $(shell touch .deps/hypothesis .deps/hypothesispytest)
+endif
+
 test-local:
 	source testenv; \
 	make webserver && \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(2) do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "adsy-centos-6.5.box"
-  config.vm.box_url = "https://adfinis-sygroup.ch/file-exchange-public/adsy-centos-6.5.box"
+  config.vm.box_url = "https://pkg.adfinis-sygroup.ch/vagrant/adsy-centos-6.5.box"
   config.vm.box_download_checksum = "a0f2cc25560495cd927da103659a59d69b2e4f1bf032ee67f35e8ea1b1c88a80"
   config.vm.box_download_checksum_type = "sha256"
   begin

--- a/pyaptly/__init__.py
+++ b/pyaptly/__init__.py
@@ -87,7 +87,7 @@ def time_remove_tz(time):
     )
 
 
-def time_delta_helper(time):
+def time_delta_helper(time):  # pragma: no cover
     """Convert a :py:class`datetime.time` to :py:class`datetime.datetime` to
     calculate deltas
 
@@ -418,7 +418,7 @@ class Command(object):
             if cmd not in scheduled
         ]
 
-        if len(unresolved) > 0:
+        if len(unresolved) > 0:  # pragma: no cover
             raise ValueError('Commands with unresolved deps: %s' % [
                 str(cmd) for cmd in unresolved
             ])

--- a/pyaptly/dateround_test.py
+++ b/pyaptly/dateround_test.py
@@ -28,7 +28,7 @@ if sys.version_info < (2, 7):  # pragma: no cover
 
 @test.hypothesis_min_ver
 @given(datetimes())
-def test_is_to_gregorian(date):
+def test_is_to_gregorian(date):  # pragma: no cover
     """Test if a roundtrip of isoclander() -> iso_to_gregorian() is correct"""
     iso_tuple = date.isocalendar()
     new_date  = iso_to_gregorian(*iso_tuple)
@@ -42,7 +42,7 @@ def test_is_to_gregorian(date):
     datetimes(min_year=2),
     integers(min_value=1, max_value=7),
     times())
-def test_round_weekly(date, day_of_week, time):
+def test_round_weekly(date, day_of_week, time):  # pragma: no cover
     """Test if the round function rounds the expected delta"""
     time            = time_remove_tz(time)
     round_date      = date_round_weekly(date, day_of_week, time)
@@ -117,7 +117,7 @@ def test_weekly_examples():
 
 @test.hypothesis_min_ver
 @given(datetimes(), times())
-def test_round_daily(date, time):
+def test_round_daily(date, time):  # pragma: no cover
     """Test if the round function rounds the expected delta"""
     time            = time_remove_tz(time)
     round_date      = date_round_daily(date, time)

--- a/pyaptly/dateround_test.py
+++ b/pyaptly/dateround_test.py
@@ -12,7 +12,7 @@ _test_base = os.path.dirname(
 ).encode("UTF-8")
 
 
-if not sys.version_info < (2, 7):
+if not sys.version_info < (2, 7):  # pragma: no cover
     from hypothesis import given  # noqa
     from hypothesis.extra.datetime import datetimes, times  # noqa
     from hypothesis.strategies import integers  # noqa

--- a/pyaptly/graph_test.py
+++ b/pyaptly/graph_test.py
@@ -4,7 +4,7 @@ import sys
 
 from . import Command, FunctionCommand, test
 
-if not sys.version_info < (2, 7):
+if not sys.version_info < (2, 7):  # pragma: no cover
     from hypothesis import strategies as st
     from hypothesis import given
 
@@ -21,7 +21,7 @@ range_intagers_st = st.integers(min_value=0, max_value=RES_COUNT)
 
 
 @st.composite
-def provide_require_st(draw, filter_=True):
+def provide_require_st(draw, filter_=True):  # pragma: no cover
     commands = draw(range_intagers_st)
     provides = draw(
         st.lists(
@@ -109,7 +109,7 @@ def test_graph_island(tree0, tree1, rnd):  # pragma: no cover
     run_graph(tree)
 
 
-def run_graph(tree):
+def run_graph(tree):  # pragma: no cover
     """Runs the test"""
     commands = []
     index = list(range(len(tree[0])))

--- a/pyaptly/graph_test.py
+++ b/pyaptly/graph_test.py
@@ -80,7 +80,7 @@ def print_example():  # pragma: no cover
 
 @test.hypothesis_min_ver
 @given(provide_require_st(), st.random_module())
-def test_graph_basic(tree, rnd):
+def test_graph_basic(tree, rnd):  # pragma: no cover
     """Test our test method, create a basic graph using hypthesis and run some
     basic tests against it."""
     run_graph(tree)
@@ -88,7 +88,7 @@ def test_graph_basic(tree, rnd):
 
 @test.hypothesis_min_ver
 @given(provide_require_st(False), st.random_module())
-def test_graph_cycles(tree, rnd):
+def test_graph_cycles(tree, rnd):  # pragma: no cover
     """Test reacts correctly on trees with cycles."""
     try:
         run_graph(tree)
@@ -103,7 +103,7 @@ def test_graph_cycles(tree, rnd):
     provide_require_st(),
     st.random_module()
 )
-def test_graph_island(tree0, tree1, rnd):
+def test_graph_island(tree0, tree1, rnd):  # pragma: no cover
     """Test with two independant graphs which can form a island"""
     tree = (tree0[0] + tree1[0], tree0[1] + tree1[1], tree0[2] + tree1[2])
     run_graph(tree)

--- a/pyaptly/test.py
+++ b/pyaptly/test.py
@@ -129,7 +129,8 @@ def clean_and_config(test_input, freeze="2012-10-10 10:10:10"):
     :param     freeze: str
     :rtype:            (dict, str)
     """
-    if b"pyaptly" not in environb[b'HOME']:  # pragma: no cover
+    old_home = environb[b'HOME']
+    if b"pyaptly" not in old_home and b"vagrant" not in old_home:  # pragma: no cover  # noqa
         raise ValueError(
             "Not safe to test here. Either you haven't set HOME to the "
             "repository path %s. Or you havn't checked out the repository "
@@ -138,7 +139,6 @@ def clean_and_config(test_input, freeze="2012-10-10 10:10:10"):
     file_ = None
     new_home = None
     try:
-        old_home = environb[b'HOME']
         new_home = os.path.join(old_home, b".work")
         try:
             shutil.rmtree(new_home)

--- a/pyaptly/test_test.py
+++ b/pyaptly/test_test.py
@@ -7,7 +7,7 @@ import unittest
 
 from . import test
 
-if not sys.version_info < (2, 7):
+if not sys.version_info < (2, 7):  # pragma: no cover
     import hypothesis.strategies as st
     from hypothesis import example, given  # noqa
 
@@ -84,14 +84,14 @@ class TestTest(unittest.TestCase):
                 except (TypeError, KeyError):
                     pass
 
-    def get_path(self, path, data):
+    def get_path(self, path, data):  # pragma: no cover
         for i in path:
             data = data[i]
         if isinstance(data, dict):
             return None
         return data
 
-    def rand_path(self, data):
+    def rand_path(self, data):  # pragma: no cover
         path = []
         while True:
             if isinstance(data, dict):

--- a/pyaptly/test_test.py
+++ b/pyaptly/test_test.py
@@ -59,7 +59,7 @@ class TestTest(unittest.TestCase):
     @test.hypothesis_min_ver
     @given(yml_st, yml_st, st.random_module())
     @example({'1': 'Huhu'}, {'1': 'None'}, st.random_module())
-    def test_merge(self, a, b, rand):
+    def test_merge(self, a, b, rand):  # pragma: no cover
         """Test if merge has the expected result."""
         res  = test.merge(a, b)
         for _ in range(10):


### PR DESCRIPTION
pyaptly still runs under python 2.6 but this is not tested anymore.

As this is still an requirement added python 2.6 to travis again working around hypothesis tests which do not run under 2.6.